### PR TITLE
CHE-10167 Add a handler to the runCommand factory's actions

### DIFF
--- a/browser-app/package.json
+++ b/browser-app/package.json
@@ -3,24 +3,24 @@
   "name": "browser-app",
   "version": "0.0.1",
   "dependencies": {
-    "@theia/core": "0.3.13",
-    "@theia/editor": "0.3.13",
-    "@theia/filesystem": "0.3.13",
-    "@theia/languages": "0.3.13",
-    "@theia/markers": "0.3.13",
-    "@theia/messages": "0.3.13",
-    "@theia/monaco": "0.3.13",
-    "@theia/navigator": "0.3.13",
-    "@theia/preferences": "0.3.13",
-    "@theia/process": "0.3.13",
-    "@theia/terminal": "0.3.13",
-    "@theia/typescript": "0.3.13",
-    "@theia/workspace": "0.3.13",
+    "@theia/core": "0.3.14",
+    "@theia/editor": "0.3.14",
+    "@theia/filesystem": "0.3.14",
+    "@theia/languages": "0.3.14",
+    "@theia/markers": "0.3.14",
+    "@theia/messages": "0.3.14",
+    "@theia/monaco": "0.3.14",
+    "@theia/navigator": "0.3.14",
+    "@theia/preferences": "0.3.14",
+    "@theia/process": "0.3.14",
+    "@theia/terminal": "0.3.14",
+    "@theia/typescript": "0.3.14",
+    "@theia/workspace": "0.3.14",
     "@eclipse-che/theia-factory-extension": "0.0.1"
   },
   "license": "EPL-2.0",
   "devDependencies": {
-    "@theia/cli": "0.3.13"
+    "@theia/cli": "0.3.14"
   },
   "scripts": {
     "prepare": "theia build",

--- a/che-theia-factory/package.json
+++ b/che-theia-factory/package.json
@@ -10,9 +10,9 @@
   ],
   "dependencies": {
     "@eclipse-che/workspace-client": "latest",
-    "@theia/core": "0.3.13",
-    "@theia/editor": "0.3.13",
-    "@theia/git": "0.3.13",
+    "@theia/core": "0.3.14",
+    "@theia/editor": "0.3.14",
+    "@theia/git": "0.3.14",
     "axios": "0.18.0"
   },
   "devDependencies": {

--- a/che-theia-factory/package.json
+++ b/che-theia-factory/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@eclipse-che/workspace-client": "latest",
     "@theia/core": "0.3.14",
+    "@theia/task": "0.3.14",
     "@theia/editor": "0.3.14",
     "@theia/git": "0.3.14",
     "axios": "0.18.0"


### PR DESCRIPTION
Add a handler to the runCommand factory's actions

Related issue: https://github.com/eclipse/che/issues/10167

Signed-off-by: Oleksii Orel <oorel@redhat.com>