### PR TITLE
fixing git not ready when cloning projects from a factory

### DIFF
--- a/che-theia-factory/src/browser/factory-theia-client.ts
+++ b/che-theia-factory/src/browser/factory-theia-client.ts
@@ -59,6 +59,7 @@ export class FactoryTheiaClient implements FrontendApplicationContribution {
                 @inject(FrontendApplicationStateService) protected readonly frontendApplicationStateService: FrontendApplicationStateService,
                 @inject(FactoryTheiaManager) private readonly factoryManager: FactoryTheiaManager) {
         this.frontendApplicationStateService.reachedState('ready').then(() => {
+            this.onReady();
             this.appLoadedEmitter.fire({actions: this.onAppLoadedActions});
         });
 
@@ -100,6 +101,10 @@ export class FactoryTheiaClient implements FrontendApplicationContribution {
     }
 
     async onStart(app: FrontendApplication) {
+        // load this module at FrontendApplication startup
+    }
+
+    async onReady() {
         const factory = await this.factoryManager.fetchCurrentFactory();
         if (!factory) {
             return;
@@ -110,6 +115,7 @@ export class FactoryTheiaClient implements FrontendApplicationContribution {
             return;
         }
 
+        console.info("Che Factory setup ...");
         const projectsRootEnvVar = this.getEnvVariable('CHE_PROJECTS_ROOT');
         if (projectsRootEnvVar && projectsRootEnvVar.value) {
             this.projectsRoot = projectsRootEnvVar.value;


### PR DESCRIPTION
Fixing this https://github.com/eclipse/che/issues/10663
Which is actually happening from time to time when the module is loading too early and cloning is done too early as well. So now we start cloning and triggering actions when the application is 'ready'.
Frontend app onStart is just used to register the application when it is ready