### PR TITLE
Automatically cloning projects defined in a workspace if not present.

### DIFF
--- a/src/che-workspace-project-manager.ts
+++ b/src/che-workspace-project-manager.ts
@@ -1,0 +1,69 @@
+/*********************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { TheiaCloneCommand } from './theia-commands';
+import { CheWorkspaceApi, CheWorkspace } from './che-api';
+import * as theia from '@theia/plugin';
+const fs = require('fs');
+
+/**
+ * Make synchronization between projects defined in Che workspace and theia projects.
+ */
+export class CheWorkspaceProjectManager {
+
+    private readonly cheWorkspaceApi: CheWorkspaceApi;
+
+    constructor() {
+        this.cheWorkspaceApi = new CheWorkspaceApi();
+    }
+
+    async onStart() {
+        const workspaceConfig = await this.getCurrentWorkspaceConfigFromCheMaster();
+        if (!workspaceConfig) {
+            theia.window.showErrorMessage('No Che workspace could be found');
+            return;
+        }
+
+        const cloneCommandList = await this.selectProjectToCloneCommands(workspaceConfig);
+        await this.executeCloneCommands(cloneCommandList);
+
+    }
+
+    private async getCurrentWorkspaceConfigFromCheMaster(): Promise<CheWorkspace | undefined> {
+        return await this.cheWorkspaceApi.retrieveWorkspaceDefinition();
+    }
+
+    async selectProjectToCloneCommands(workspaceConfig: CheWorkspace): Promise<TheiaCloneCommand[]> {
+        let projectsRoot = '/projects';
+        const projectsRootEnvVar = await theia.env.getEnvVariable('CHE_PROJECTS_ROOT');
+        if (projectsRootEnvVar) {
+            projectsRoot = projectsRootEnvVar;
+        }
+
+        const projects = workspaceConfig.getProjects();
+
+        return projects
+            .filter(
+                project => !fs.existsSync(projectsRoot + project.getPath()))
+            .map(
+                project => new TheiaCloneCommand(
+                    project.getLocationURI(),
+                    projectsRoot + project.getPath(),
+                    project.getCheckoutBranch()));
+    }
+
+    private async executeCloneCommands(cloneCommandList: TheiaCloneCommand[]) {
+        await Promise.all(
+            cloneCommandList.map(cloneCommand => cloneCommand.execute())
+        );
+        theia.window.showInformationMessage("Che Workspace: Finished clonning projects.");
+    }
+
+}

--- a/src/factory-theia-client.ts
+++ b/src/factory-theia-client.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import { TheiaCloneCommand, TheiaCommand } from './theia-commands';
-import { CheFactoryApi, CheFactory } from './che-factory-api';
+import { CheFactoryApi, CheFactory } from './che-api';
 import * as theia from '@theia/plugin';
 
 export enum ActionId {

--- a/src/plugin-backend-plugin.ts
+++ b/src/plugin-backend-plugin.ts
@@ -9,9 +9,11 @@
  **********************************************************************/
 
 import { FactoryTheiaClient } from "./factory-theia-client";
+import { CheWorkspaceProjectManager } from "./che-workspace-project-manager";
 
 export async function start() {
     new FactoryTheiaClient().onStart();
+    new CheWorkspaceProjectManager().onStart();
 }
 
 export function stop() {

--- a/src/theia-commands.ts
+++ b/src/theia-commands.ts
@@ -79,7 +79,7 @@ export class TheiaCommand {
                     });
             }
         }
-        return new Promise(() => { console.error('action nor openfile nor run command') });
+        return new Promise(() => { console.error('action nor openfile nor run command'); });
 
     }
 


### PR DESCRIPTION
this PR is adding new feature in the plugin (that is not handling only factory anymore):

- cloning projects defined in the workspace definition if not present